### PR TITLE
pr-auditor: update workflow to use new repo

### DIFF
--- a/.github/workflows/pr-auditor.yml
+++ b/.github/workflows/pr-auditor.yml
@@ -1,19 +1,21 @@
+# See https://docs.sourcegraph.com/dev/background-information/ci#pr-auditor
 name: pr-auditor
 on:
-  pull_request:
-    types: [ closed, edited, opened ]
+  pull_request_target:
+    types: [ closed, edited, opened, synchronize, ready_for_review ]
 
 jobs:
-  run:
+  check-pr:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-        with: { repository: 'sourcegraph/sourcegraph' }
-      - uses: actions/setup-go@v2
-        with: { go-version: '1.17' }
+      - uses: actions/checkout@v3
+        with:
+          repository: 'sourcegraph/pr-auditor'
+      - uses: actions/setup-go@v4
+        with: { go-version: '1.20' }
 
-      - run: ./dev/pr-auditor/check-pr.sh
+      - run: './check-pr.sh'
         env:
           GITHUB_EVENT_PATH: ${{ env.GITHUB_EVENT_PATH }}
-          GITHUB_TOKEN: ${{ secrets.CODENOTIFY_GITHUB_TOKEN }}
-          GITHUB_RUN_URL: https://github.com/sourcegraph/infrastructure/actions/runs/${{ github.run_id }}
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
Update the workflow to use the new `sourcegraph/pr-auditor` repo
## Test plan
Tested in `sourcegraph/sourcegraph`

[_Created by Sourcegraph batch change `burmudar/pr-auditor-update`._](https://sourcegraph.sourcegraph.com/users/burmudar/batch-changes/pr-auditor-update)